### PR TITLE
fix(security): address OSS readiness review issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Sello
 
 [![CI](https://github.com/sello-project/sello/actions/workflows/ci.yml/badge.svg)](https://github.com/sello-project/sello/actions/workflows/ci.yml)
+[![Crates.io](https://img.shields.io/crates/v/sello.svg)](https://crates.io/crates/sello)
+[![Documentation](https://img.shields.io/badge/docs-user_guide-blue)](docs/USER_GUIDE.md)
+[![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](LICENSE-MIT)
 
 Multi-chain transaction signing service with policy engine.
 


### PR DESCRIPTION
## Summary

Addresses issues identified during OSS readiness review by the council of agents:

- **Security**: Improve zeroization of sensitive data (decrypted plaintext, key hex)
- **Tests**: Add comprehensive Bitcoin SegWit/Taproot tests and fix Solana token transfer tests
- **Docs**: Document exit codes, add Bitcoin/Solana CLI reference, add JSON output examples
- **README**: Add badges for crates.io, documentation, and license

## Changes

### Security Improvements
- Wrap decrypted plaintext in `Zeroizing<Vec<u8>>` for automatic cleanup on drop
- Use `Zeroizing<String>` for `key_hex` field in `ImportCommand`

### Test Coverage (12 new Bitcoin tests)
- SegWit transaction parsing and metadata
- Taproot (P2TR) transaction parsing
- OP_RETURN transaction type detection
- P2WPKH address extraction (mainnet `bc1q...`)
- P2TR address extraction (mainnet `bc1p...`)
- Testnet address format verification
- Helper function unit tests (`is_segwit`, `is_taproot`, `determine_tx_type`)

### Solana Test Fixes
- Fixed SPL Token transfer tests by aligning owner with fee payer signer

### Documentation
- Added exit codes section (0=success, 1=policy denied, 2=error)
- Added complete CLI reference for Bitcoin and Solana commands
- Added JSON output examples for Ethereum, Bitcoin, and Solana
- Added README badges (crates.io, docs, license)

## Test plan

- [x] All 1,500+ tests pass
- [x] Clippy passes with no warnings
- [x] Formatting is correct
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.ai/code)