### PR TITLE
feat(cli): add --allow-env-passphrase flag to txgate init

### DIFF
--- a/crates/txgate/src/cli/commands/status.rs
+++ b/crates/txgate/src/cli/commands/status.rs
@@ -503,10 +503,15 @@ mod tests {
         // Create directories
         fs::create_dir_all(base_dir.join(KEYS_DIR_NAME)).expect("failed to create keys dir");
 
-        // Create default config
+        // Create config with socket_path inside the temp dir so the test
+        // doesn't accidentally detect a real running server at ~/.txgate/.
         let config_path = base_dir.join(CONFIG_FILE_NAME);
-        let default_config = Config::default_toml();
-        fs::write(&config_path, default_config).expect("failed to write config");
+        let socket_path = base_dir.join("txgate.sock");
+        let config = Config::default_toml().replace(
+            "socket_path = \"~/.txgate/txgate.sock\"",
+            &format!("socket_path = \"{}\"", socket_path.display()),
+        );
+        fs::write(&config_path, config).expect("failed to write config");
 
         // Create a default key file (mock)
         let key_path = base_dir.join(KEYS_DIR_NAME).join("default.enc");

--- a/crates/txgate/src/cli/mod.rs
+++ b/crates/txgate/src/cli/mod.rs
@@ -17,7 +17,7 @@
 //! let cli = Cli::parse();
 //!
 //! match cli.command {
-//!     Commands::Init { force } => {
+//!     Commands::Init { force, allow_env_passphrase } => {
 //!         // Handle init command
 //!     }
 //!     Commands::Status => {
@@ -30,7 +30,7 @@
 //!
 //! ## Commands
 //!
-//! - `txgate init [--force]` - Initialize `TxGate` configuration
+//! - `txgate init [--force] [--allow-env-passphrase]` - Initialize `TxGate` configuration
 //! - `txgate status` - Display current status
 //! - `txgate config [edit|path]` - View or edit configuration
 //! - `txgate serve [--foreground]` - Start the signing server

--- a/crates/txgate/src/main.rs
+++ b/crates/txgate/src/main.rs
@@ -82,8 +82,11 @@ fn main() {
 
     // Dispatch to command handlers
     let result = match cli.command {
-        Commands::Init { force } => {
-            let cmd = InitCommand::new(force);
+        Commands::Init {
+            force,
+            allow_env_passphrase,
+        } => {
+            let cmd = InitCommand::new(force, allow_env_passphrase);
             cmd.run().map_err(|e| e.to_string())
         }
         Commands::Status => {

--- a/crates/txgate/tests/unit/cli_integration_test.rs
+++ b/crates/txgate/tests/unit/cli_integration_test.rs
@@ -20,11 +20,23 @@ use txgate::cli::{Cli, Commands, ConfigAction, EthereumCommands, OutputFormat};
 fn test_cli_command_dispatch() {
     // Test init command
     let cli = Cli::try_parse_from(["txgate", "init"]).expect("should parse");
-    assert!(matches!(cli.command, Commands::Init { force: false }));
+    assert!(matches!(
+        cli.command,
+        Commands::Init {
+            force: false,
+            allow_env_passphrase: false
+        }
+    ));
 
     // Test init with force
     let cli = Cli::try_parse_from(["txgate", "init", "--force"]).expect("should parse");
-    assert!(matches!(cli.command, Commands::Init { force: true }));
+    assert!(matches!(
+        cli.command,
+        Commands::Init {
+            force: true,
+            allow_env_passphrase: false
+        }
+    ));
 
     // Test status command
     let cli = Cli::try_parse_from(["txgate", "status"]).expect("should parse");


### PR DESCRIPTION
## Summary

- Add `--allow-env-passphrase` flag to `txgate init` for fully non-interactive initialization when `TXGATE_PASSPHRASE` is set
- Without the flag, init is interactive: prompts for passphrase then asks y/n about enabling env-var passphrase
- The chosen setting is written as `allow_env_passphrase = true/false` (uncommented) in `config.toml`
- Fix flaky status tests (`test_status_command_initialized`, `test_status_output_fields`) that failed when a real txgate server was running

## Behavior

| `--allow-env-passphrase` | `TXGATE_PASSPHRASE` set? | Behavior |
|--------------------------|--------------------------|----------|
| Yes | Yes | Non-interactive: uses env var, config has `allow_env_passphrase = true` |
| Yes | No  | Error: `--allow-env-passphrase requires TXGATE_PASSPHRASE to be set` |
| No  | *(ignored)* | Interactive: prompts passphrase, asks y/n, config reflects choice |

## Bug fix

Status tests used `Config::default_toml()` which points `socket_path` at `~/.txgate/txgate.sock`. When a real server was running, `check_server_running` returned `true` and the `assert!(!output.server_running)` assertion failed. Fixed by overriding the socket path to point inside the temp dir.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo test --workspace` — 489 passed, 0 failed
- [ ] Manual: `TXGATE_PASSPHRASE=test txgate init --allow-env-passphrase` — non-interactive, config has `allow_env_passphrase = true`
- [ ] Manual: `txgate init --allow-env-passphrase` (no env var) — error
- [ ] Manual: `txgate init` — interactive, asks y/n

🤖 Generated with [Claude Code](https://claude.com/claude-code)